### PR TITLE
These files should not be generated outside target/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,3 @@ buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
-*.interp
-*.tokens

--- a/language/.project
+++ b/language/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -19,5 +24,6 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
Antlr4 files should be generated in target.
Maven already is configured to do this but the plugin needs to be desactivate in `Window -> Preferences -> ANTLR4 -> Tool`.

This should not appear in Console anymore:
```
ANTLR Tool v4.4 (/tmp/antlr-4.4-complete.jar)
Tcl.g4 -o /home/damien/source/repos/graaltcl/language -listener -visitor -encoding UTF-8

BUILD SUCCESSFUL
Total time: 394 millisecond(s)
```

If this text keep appearing, try to check all the cheackboxs in the `Window -> Preferences -> ANTLR4 -> Tool`, then apply, then uncheck all the cheackboxs and finally apply and close.